### PR TITLE
4 packages from rocq-community/trocq at 0.2.0

### DIFF
--- a/released/packages/coq-trocq-hott-examples/coq-trocq-hott-examples.0.2.0/opam
+++ b/released/packages/coq-trocq-hott-examples/coq-trocq-hott-examples.0.2.0/opam
@@ -1,0 +1,45 @@
+opam-version: "2.0"
+maintainer: "Cyril Cohen <cyril.cohen@inria.fr>"
+
+homepage: "https://github.com/coq-community/trocq"
+dev-repo: "git+https://github.com/coq-community/trocq.git"
+bug-reports: "https://github.com/coq-community/trocq/issues"
+license: "LGPL-3.0-or-later"
+
+synopsis: "A modular parametricity plugin for proof transfer in Coq: examples"
+description: """
+Tests for applications of Trocq
+"""
+
+build: [make "-C examples/hott" "-j%{jobs}%"]
+install: [make "-C examples/hott"  "install"]
+depends: [
+  "coq" {>= "8.20" & < "9.1"}
+  "coq-trocq-hott"
+]
+
+tags: [
+  "category:Computer Science/Decision Procedures and Certified Algorithms/Decision procedures"
+  "category:Miscellaneous/Coq Extensions"
+  "keyword:automation"
+  "keyword:elpi"
+  "keyword:proof transfer"
+  "keyword:isomorphism"
+  "keyword:univalence"
+  "keyword:parametricity"
+  "logpath:Trocq"
+]
+authors: [
+  "Cyril Cohen"
+  "Enzo Crance"
+  "Lucie Lahaye"
+  "Assia Mahboubi"
+]
+url {
+  src:
+    "https://github.com/rocq-community/trocq/archive/refs/tags/0.2.0.tar.gz"
+  checksum: [
+    "md5=14ee380ce5141d67f34bade89c0dc8df"
+    "sha512=1827f6478eb004e358b33785bf2007ec314b46fc75324e2b2a722d9ca19a6b005d019eb5e4ab016d7b85e4f11b69e29375ef9826ab5d160fbe7ef60cad138824"
+  ]
+}

--- a/released/packages/coq-trocq-hott/coq-trocq-hott.0.2.0/opam
+++ b/released/packages/coq-trocq-hott/coq-trocq-hott.0.2.0/opam
@@ -1,0 +1,71 @@
+# This file was generated from `meta.yml`, please do not edit manually.
+# Follow the instructions on https://github.com/coq-community/templates to regenerate.
+
+opam-version: "2.0"
+maintainer: "Enzo Crance <enzo.crance@inria.fr>"
+
+homepage: "https://github.com/coq-community/trocq"
+dev-repo: "git+https://github.com/coq-community/trocq.git"
+bug-reports: "https://github.com/coq-community/trocq/issues"
+license: "LGPL-3.0-or-later"
+
+synopsis: "A modular parametricity plugin for proof transfer in Coq"
+description: """
+Trocq is a modular parametricity plugin for Coq. It can be used to
+achieve proof transfer by both translating a user goal into another,
+related, variant, and computing a proof that proves the corresponding implication.
+
+The plugin features a hierarchy of structures on relations, whose
+instances are computed from registered user-defined proof via
+parametricity. This hierarchy ranges from structure-less relations
+to an original formulation of type equivalence. The resulting
+framework generalizes [raw
+parametricity](https://arxiv.org/abs/1209.6336), [univalent
+parametricity](https://doi.org/10.1145/3429979) and
+[CoqEAL](https://github.com/coq-community/coqeal), and includes them
+in a unified framework.
+
+The plugin computes a parametricity translation "à la carte", by
+performing a fine-grained analysis of the requires properties for a
+given proof of relatedness. In particular, it is able to prove
+implications without resorting to full-blown type equivalence,
+allowing this way to perform proof transfer without necessarily
+pulling in the univalence axiom.
+
+The plugin is implemented in Coq-Elpi and the code of the
+parametricity translation is fairly close to a pen-and-paper
+sequent-style presentation."""
+
+build: [make "-j%{jobs}%" "hott"]
+install: [make "install" "-C hott"]
+depends: [
+  "coq" {>= "8.20" & < "9.1"}
+  "coq-elpi" {= "2.5.2"}
+  "coq-hott"
+]
+
+tags: [
+  "category:Computer Science/Decision Procedures and Certified Algorithms/Decision procedures"
+  "category:Miscellaneous/Coq Extensions"
+  "keyword:automation"
+  "keyword:elpi"
+  "keyword:proof transfer"
+  "keyword:isomorphism"
+  "keyword:univalence"
+  "keyword:parametricity"
+  "logpath:Trocq"
+]
+authors: [
+  "Cyril Cohen"
+  "Enzo Crance"
+  "Lucie Lahaye"
+  "Assia Mahboubi"
+]
+url {
+  src:
+    "https://github.com/rocq-community/trocq/archive/refs/tags/0.2.0.tar.gz"
+  checksum: [
+    "md5=14ee380ce5141d67f34bade89c0dc8df"
+    "sha512=1827f6478eb004e358b33785bf2007ec314b46fc75324e2b2a722d9ca19a6b005d019eb5e4ab016d7b85e4f11b69e29375ef9826ab5d160fbe7ef60cad138824"
+  ]
+}

--- a/released/packages/coq-trocq-std-examples/coq-trocq-std-examples.0.2.0/opam
+++ b/released/packages/coq-trocq-std-examples/coq-trocq-std-examples.0.2.0/opam
@@ -1,0 +1,46 @@
+opam-version: "2.0"
+maintainer: "Cyril Cohen <cyril.cohen@inria.fr>"
+
+homepage: "https://github.com/coq-community/trocq"
+dev-repo: "git+https://github.com/coq-community/trocq.git"
+bug-reports: "https://github.com/coq-community/trocq/issues"
+license: "LGPL-3.0-or-later"
+
+synopsis: "A modular parametricity plugin for proof transfer in Coq: examples"
+description: """
+Tests for applications of Trocq
+"""
+
+build: [make "-C examples/std" "-j%{jobs}%"]
+install: [make "-C examples/std"  "install"]
+depends: [
+  "coq" {>= "8.20" & < "9.1"}
+  "coq-mathcomp-algebra"
+  "coq-trocq-std"
+]
+
+tags: [
+  "category:Computer Science/Decision Procedures and Certified Algorithms/Decision procedures"
+  "category:Miscellaneous/Coq Extensions"
+  "keyword:automation"
+  "keyword:elpi"
+  "keyword:proof transfer"
+  "keyword:isomorphism"
+  "keyword:univalence"
+  "keyword:parametricity"
+  "logpath:Trocq"
+]
+authors: [
+  "Cyril Cohen"
+  "Enzo Crance"
+  "Lucie Lahaye"
+  "Assia Mahboubi"
+]
+url {
+  src:
+    "https://github.com/rocq-community/trocq/archive/refs/tags/0.2.0.tar.gz"
+  checksum: [
+    "md5=14ee380ce5141d67f34bade89c0dc8df"
+    "sha512=1827f6478eb004e358b33785bf2007ec314b46fc75324e2b2a722d9ca19a6b005d019eb5e4ab016d7b85e4f11b69e29375ef9826ab5d160fbe7ef60cad138824"
+  ]
+}

--- a/released/packages/coq-trocq-std/coq-trocq-std.0.2.0/opam
+++ b/released/packages/coq-trocq-std/coq-trocq-std.0.2.0/opam
@@ -1,0 +1,70 @@
+# This file was generated from `meta.yml`, please do not edit manually.
+# Follow the instructions on https://github.com/coq-community/templates to regenerate.
+
+opam-version: "2.0"
+maintainer: "Enzo Crance <enzo.crance@inria.fr>"
+
+homepage: "https://github.com/coq-community/trocq"
+dev-repo: "git+https://github.com/coq-community/trocq.git"
+bug-reports: "https://github.com/coq-community/trocq/issues"
+license: "LGPL-3.0-or-later"
+
+synopsis: "A modular parametricity plugin for proof transfer in Coq"
+description: """
+Trocq is a modular parametricity plugin for Coq. It can be used to
+achieve proof transfer by both translating a user goal into another,
+related, variant, and computing a proof that proves the corresponding implication.
+
+The plugin features a hierarchy of structures on relations, whose
+instances are computed from registered user-defined proof via
+parametricity. This hierarchy ranges from structure-less relations
+to an original formulation of type equivalence. The resulting
+framework generalizes [raw
+parametricity](https://arxiv.org/abs/1209.6336), [univalent
+parametricity](https://doi.org/10.1145/3429979) and
+[CoqEAL](https://github.com/coq-community/coqeal), and includes them
+in a unified framework.
+
+The plugin computes a parametricity translation "à la carte", by
+performing a fine-grained analysis of the requires properties for a
+given proof of relatedness. In particular, it is able to prove
+implications without resorting to full-blown type equivalence,
+allowing this way to perform proof transfer without necessarily
+pulling in the univalence axiom.
+
+The plugin is implemented in Coq-Elpi and the code of the
+parametricity translation is fairly close to a pen-and-paper
+sequent-style presentation."""
+
+build: [make "-j%{jobs}%" "std"]
+install: [make "-C std" "install"]
+depends: [
+  "coq" {>= "8.20" & < "9.1"}
+  "coq-elpi" {= "2.5.2"}
+]
+
+tags: [
+  "category:Computer Science/Decision Procedures and Certified Algorithms/Decision procedures"
+  "category:Miscellaneous/Coq Extensions"
+  "keyword:automation"
+  "keyword:elpi"
+  "keyword:proof transfer"
+  "keyword:isomorphism"
+  "keyword:univalence"
+  "keyword:parametricity"
+  "logpath:Trocq"
+]
+authors: [
+  "Cyril Cohen"
+  "Enzo Crance"
+  "Lucie Lahaye"
+  "Assia Mahboubi"
+]
+url {
+  src:
+    "https://github.com/rocq-community/trocq/archive/refs/tags/0.2.0.tar.gz"
+  checksum: [
+    "md5=14ee380ce5141d67f34bade89c0dc8df"
+    "sha512=1827f6478eb004e358b33785bf2007ec314b46fc75324e2b2a722d9ca19a6b005d019eb5e4ab016d7b85e4f11b69e29375ef9826ab5d160fbe7ef60cad138824"
+  ]
+}


### PR DESCRIPTION
This pull-request concerns:
- `coq-trocq-hott.0.2.0`: A modular parametricity plugin for proof transfer in Coq
- `coq-trocq-hott-examples.0.2.0`: A modular parametricity plugin for proof transfer in Coq: examples
- `coq-trocq-std.0.2.0`: A modular parametricity plugin for proof transfer in Coq
- `coq-trocq-std-examples.0.2.0`: A modular parametricity plugin for proof transfer in Coq: examples



---
* Homepage: https://github.com/coq-community/trocq
* Source repo: git+https://github.com/coq-community/trocq.git
* Bug tracker: https://github.com/coq-community/trocq/issues

---
:camel: Pull-request generated by opam-publish v2.5.1